### PR TITLE
feat(AnimeKai): add activity

### DIFF
--- a/websites/A/AnimeKai/metadata.json
+++ b/websites/A/AnimeKai/metadata.json
@@ -10,9 +10,9 @@
     "en": "AnimeKai.to - A site to watch anime online for Free"
   },
   "url": "animekai.to",
-  "version": "2.0.0",
-  "logo": "https://animekai.to/assets/uploads/37585a39fe8c8d8fafaa2c7bfbf5374ecac859ea6a0288a6da2c61f5.png",
-  "thumbnail": "https://animekai.to/assets/uploads/37585a39fe8c8d8fafaa2c7bfbf5374ecac859ea6a0886b7dc.png",
+  "version": "1.0.0",
+  "logo": "https://i.imgur.com/cBDeiXA.png",
+  "thumbnail": "https://i.imgur.com/UH163D5.png",
   "color": "#40b15d",
   "category": "anime",
   "tags": [

--- a/websites/A/AnimeKai/presence.ts
+++ b/websites/A/AnimeKai/presence.ts
@@ -1,260 +1,218 @@
 import { ActivityType, Assets } from 'premid'
 
 const presence = new Presence({
-		clientId: "1264754447276310599",
-	}),
-	strings = presence.getStrings({
-		play: "general.playing",
-		pause: "general.paused",
-	})
+  clientId: '1264754447276310599',
+})
+const strings = presence.getStrings({
+  play: 'general.playing',
+  pause: 'general.paused',
+})
 const browsingTimestamp = Math.floor(Date.now() / 1000)
 
 let data: {
-  currTime: number;
-  duration: number;
-  paused: boolean;
-} = null as any;
+  currTime: number
+  duration: number
+  paused: boolean
+} = null as any
 
 enum ActivityAssets { // Other default assets can be found at index.d.ts
-	Logo = "https://animekai.to/assets/uploads/37585a39fe8c8d8fafaa2c7bfbf5374ecac859ea6a0288a6da2c61f5.png",
-	Settings = "https://cdn.rcd.gg/PreMiD/websites/A/AniWatch/assets/1.png",
-	Notifications = "https://cdn.rcd.gg/PreMiD/websites/A/AniWatch/assets/2.png",
+  Logo = 'https://i.imgur.com/cBDeiXA.png',
+  Settings = 'https://cdn.rcd.gg/PreMiD/websites/A/AniWatch/assets/1.png',
+  Notifications = 'https://cdn.rcd.gg/PreMiD/websites/A/AniWatch/assets/2.png',
 }
 
 presence.on(
-	"iFrameData",
-	async (recievedData: {
-		currTime: number;
-		duration: number;
-		paused: boolean;
-	}) => {
-		data = recievedData;
-	}
-);
+  'iFrameData',
+  async (recievedData: {
+    currTime: number
+    duration: number
+    paused: boolean
+  }) => {
+    data = recievedData
+  },
+)
 
 presence.on('UpdateData', async () => {
-	const presenceData: PresenceData = {
-			name: "AnimeKai",
-			largeImageKey: ActivityAssets.Logo,
-			startTimestamp: browsingTimestamp,
-		},
-		{ pathname, href } = document.location,
-		buttons = await presence.getSetting<boolean>("buttons");
+  const presenceData: PresenceData = {
+    name: 'AnimeKai',
+    largeImageKey: ActivityAssets.Logo,
+    startTimestamp: browsingTimestamp,
+  }
+  const { pathname, href } = document.location
+  const buttons = await presence.getSetting<boolean>('buttons')
 
-	if (pathname === "/" || pathname === "/home")
-		presenceData.details = "Exploring AnimeKai.to";
-	else if (
-		/\/(most-favorite|most-popular|movie|recently-added|recently-updated|tv|top-airing|top-upcoming|ona|ova|special|(genre\/.*)|(genres\/.*))/.test(
-			pathname
-		)
-	) {
-		const heading = document.querySelector<HTMLSpanElement>(".shead .stitle.text-uppercase");
-		if (heading) presenceData.details = `Looking at ${heading.textContent}`;
-	} else if (pathname.startsWith("/news")) {
-		presenceData.details = "Looking at Anime news";
-		if (pathname !== "/news") {
-			const title = document.querySelector<HTMLHeadingElement>("h2.news-title");
-			if (title) presenceData.state = title.textContent;
-		}
-	} else if (pathname.startsWith("/community/user")) {
-		const profile = document.querySelector<HTMLSpanElement>(
-			"#main-wrapper > div.container > div > div.ai_-welcome.text-center > span"
-		);
-		if (profile) presenceData.details = `Viewing User: ${profile.textContent}`;
-		presenceData.smallImageKey = Assets.Viewing;
-	} else if (pathname.startsWith("/producer")) {
-		const name = document.querySelector(
-			"#main-content > section > div.block_area-header.block_area-header-tabs > div.float-left.bah-heading.mr-4 > h2"
-		)?.textContent;
+  if (pathname === '/' || pathname === '/home') {
+    presenceData.details = 'Exploring AnimeKai.to'
+  }
+  else if (
+    /\/(?:ongoing|recent|movie|new-releases|updates|tv|completed|top-upcoming|ona|ova|special|genres\/.*)/.test(
+      pathname,
+    )
+  ) {
+    const heading = document.querySelector<HTMLSpanElement>('.shead .stitle.text-uppercase')
+    if (heading)
+      presenceData.details = `Looking at ${heading.textContent}`
+  }
+  else if (pathname.startsWith('/producers')) {
+    const name = document.querySelector<HTMLSpanElement>('.shead .stitle.text-uppercase')?.textContent
 
-		presenceData.details = name;
-		if (buttons) {
-			presenceData.buttons = [
-				{
-					label: "Go to Production Page",
-					url: href,
-				},
-			];
-		}
-	} else if (
-		pathname.startsWith("/people") ||
-		pathname.startsWith("/character")
-	) {
-		const name = document.querySelector<HTMLHeadingElement>("h4.name"),
-			isCharacterPage = pathname.startsWith("/character");
-		if (name) {
-			presenceData.details = `Looking at ${
-				!isCharacterPage ? "people" : "characters"
-			}`;
-			presenceData.state = name.textContent;
-		}
-		presenceData.smallImageKey = Assets.Viewing;
-		if (buttons) {
-			presenceData.buttons = [
-				{
-					label: `Go to ${
-						name || isCharacterPage ? "Character" : "People"
-					} Page`,
-					url: href,
-				},
-			];
-		}
-	} else if (pathname.startsWith("/az-list")) {
-		presenceData.details = "Looking at Anime list";
-		if (pathname !== "/az-list") {
-			presenceData.state = `Titles starting with ${
-				pathname.substring(9) === "other"
-					? "Other characters"
-					: `${pathname.substring(9)}`
-			}`;
-		}
-		presenceData.smallImageKey = Assets.Search;
-	} else if (pathname.startsWith("/watch2gether/")) {
-		if (pathname === "/watch2gether/")
-			presenceData.details = "Looking for anime rooms";
-		else {
-			const filmName =
-					document.querySelector<HTMLHeadingElement>("h2.film-name"),
-				thumbnail = document.querySelector<HTMLImageElement>(
-					".anis-watch-detail > .anis-content > .anisc-poster > .film-poster > img.film-poster-img"
-				)?.src;
+    presenceData.details = name
+    if (buttons) {
+      presenceData.buttons = [
+        {
+          label: 'Go to Production Page',
+          url: href,
+        },
+      ]
+    }
+  }
+  else if (pathname.startsWith('/az-list')) {
+    presenceData.details = 'Looking at Anime list'
+    if (pathname !== '/az-list') {
+      presenceData.state = `Titles starting with ${
+        pathname.substring(9) === 'other'
+          ? 'Other characters'
+          : `${pathname.substring(9)}`
+      }`
+    }
+    presenceData.smallImageKey = Assets.Search
+  }
+  else if (pathname.startsWith('/watch2gether')) {
+    if (pathname === '/watch2gether') {
+      presenceData.details = 'Looking for anime rooms'
+    }
+    else {
+      const filmName = document.querySelector<HTMLLIElement>(
+        'li.breadcrumb-item.active',
+      )
+      const thumbnail = document.querySelector<HTMLImageElement>(
+        '.poster > div > img',
+      )?.src
 
-			presenceData.largeImageKey = thumbnail;
-			presenceData.details = "In a room";
-			presenceData.type = ActivityType.Watching;
-			if (filmName) presenceData.state = `${filmName.textContent}`;
-			if (data && !data.paused) {
-				[presenceData.startTimestamp, presenceData.endTimestamp] =
-					presence.getTimestamps(data.currTime, data.duration);
-			}
-			if (buttons) {
-				presenceData.buttons = [
-					{
-						label: "Join Room",
-						url: href,
-					},
-				];
-			}
-		}
-	} else if (pathname.startsWith("/watch")) {
-		const title = document.querySelector<HTMLLIElement>(
-				"li.breadcrumb-item.active"
-			),
-			episodeSpan = document.querySelector<HTMLSpanElement>(
-				".eplist .range li a.active span"
-			),
-			episode = episodeSpan?.previousSibling?.nodeValue?.trim() || null,
-			thumbnail = document.querySelector<HTMLImageElement>(
-				".poster > div > img"
-			)?.src;
+      presenceData.largeImageKey = thumbnail
+      presenceData.details = 'In a room'
+      presenceData.type = ActivityType.Watching
+      if (filmName)
+        presenceData.state = `${filmName.textContent}`
+      if (data && !data.paused) {
+        [presenceData.startTimestamp, presenceData.endTimestamp] = presence.getTimestamps(data.currTime, data.duration)
+      }
+      if (buttons) {
+        presenceData.buttons = [
+          {
+            label: 'Join Room',
+            url: href,
+          },
+        ]
+      }
+    }
+  }
+  else if (pathname.startsWith('/watch')) {
+    const title = document.querySelector<HTMLLIElement>(
+      'li.breadcrumb-item.active',
+    )
+    const episodeSpan = document.querySelector<HTMLSpanElement>(
+      '.eplist .range li a.active span',
+    )
+    const episode = episodeSpan?.previousSibling?.nodeValue?.trim() || null
+    const thumbnail = document.querySelector<HTMLImageElement>(
+      '.poster > div > img',
+    )?.src
 
-		presenceData.largeImageKey = thumbnail;
-		if (title) presenceData.details = title.textContent;
-		if (episode) presenceData.state = `Episode ${episode}`;
-		if (data) {
-			presenceData.type = ActivityType.Watching;
-			if (!data.paused) {
-				[presenceData.startTimestamp, presenceData.endTimestamp] =
-					presence.getTimestamps(data.currTime, data.duration);
-				presenceData.smallImageKey = Assets.Play;
-				presenceData.smallImageText = (await strings).play;
-			} else {
-				presenceData.smallImageKey = Assets.Pause;
-				presenceData.smallImageText = (await strings).pause;
-				delete presenceData.startTimestamp;
-				delete presenceData.endTimestamp;
-			}
-		}
+    presenceData.largeImageKey = thumbnail
+    if (title)
+      presenceData.details = title.textContent
+    if (episode)
+      presenceData.state = `Episode ${episode}`
+    if (data) {
+      presenceData.type = ActivityType.Watching
+      if (!data.paused) {
+        [presenceData.startTimestamp, presenceData.endTimestamp] = presence.getTimestamps(data.currTime, data.duration)
+        presenceData.smallImageKey = Assets.Play
+        presenceData.smallImageText = (await strings).play
+      }
+      else {
+        presenceData.smallImageKey = Assets.Pause
+        presenceData.smallImageText = (await strings).pause
+        delete presenceData.startTimestamp
+        delete presenceData.endTimestamp
+      }
+    }
 
-		if (buttons) {
-			presenceData.buttons = [
-				{
-					label: "Watch Episode",
-					url: href,
-				},
-			];
-		}
-	} else if (pathname.startsWith("/event/")) {
-		const title = document.querySelector<HTMLDivElement>("div.title"),
-			description = document.querySelector<HTMLDivElement>("div.description");
-		if (title) presenceData.details = `Event: ${title.textContent}`;
-		if (description) presenceData.state = description.textContent;
-	} else if (pathname.startsWith("/community")) {
-		presenceData.details = "Community Post";
-		presenceData.state = document.title;
-		presenceData.smallImageKey = Assets.Question;
-	} else {
-		switch (pathname) {
-			case "/browser": {
-				presenceData.details = "Searching";
+    if (buttons) {
+      presenceData.buttons = [
+        {
+          label: 'Watch Episode',
+          url: href,
+        },
+      ]
+    }
+  }
+  else {
+    switch (pathname) {
+      case '/browser': {
+        presenceData.details = 'Searching'
 
-				const searchInput = document.querySelector(".search input.form-control") as HTMLInputElement | null;
-				const searchInputValue = searchInput?.value ?? "";
+        const searchInput = document.querySelector('.search input.form-control') as HTMLInputElement | null
+        const searchInputValue = searchInput?.value ?? ''
 
-				presenceData.state = searchInputValue;
-				presenceData.smallImageKey = Assets.Search;
-				break;
-			}
-			case "/events": {
-				presenceData.details = "Looking at events";
-				break;
-			}
-			case "/contact": {
-				presenceData.details = "Contact Us";
-				break;
-			}
-			case "/dmca": {
-				presenceData.details = "DMCA";
-				break;
-			}
-			case "/terms": {
-				presenceData.details = "Terms of Service";
-				break;
-			}
-			case "/user/settings": {
-				presenceData.details = "Changing Settings";
-				presenceData.smallImageKey = ActivityAssets.Settings;
-				break;
-			}
-			case "/user/notification": {
-				presenceData.details = "Looking at Notifications";
-				presenceData.smallImageKey = ActivityAssets.Notifications;
-				break;
-			}
-			case "/user/continue-watching": {
-				presenceData.details = "Continue Watching";
-				presenceData.smallImageKey = Assets.Reading;
-				break;
-			}
-			case "/user/mal": {
-				presenceData.details = "MAL Import/Export";
-				presenceData.smallImageKey = Assets.Downloading;
-				break;
-			}
-			default: {
-				const title = document.querySelector<HTMLHeadingElement>(
-					"h2.film-name.dynamic-name"
-				);
-				if (title) {
-					const thumbnail = document.querySelector<HTMLImageElement>(
-						"#ani_detail > div > div > div.anis-content > div.anisc-poster > div > img"
-					)?.src;
+        presenceData.state = searchInputValue
+        presenceData.smallImageKey = Assets.Search
+        break
+      }
+      case '/contact': {
+        presenceData.details = 'Contact Us'
+        break
+      }
+      case '/user/profile': {
+        presenceData.details = 'Checking User Profile'
+        presenceData.smallImageKey = ActivityAssets.Settings
+        break
+      }
+      case '/user/settings': {
+        presenceData.details = 'Changing Settings'
+        presenceData.smallImageKey = ActivityAssets.Settings
+        break
+      }
+      case '/user/notification': {
+        presenceData.details = 'Looking at Notifications'
+        presenceData.smallImageKey = ActivityAssets.Notifications
+        break
+      }
+      case '/user/watching': {
+        presenceData.details = 'Continue Watching'
+        presenceData.smallImageKey = Assets.Reading
+        break
+      }
+      case '/user/import': {
+        presenceData.details = 'MAL Import/Export'
+        presenceData.smallImageKey = Assets.Downloading
+        break
+      }
+      default: {
+        const title = document.querySelector<HTMLHeadingElement>(
+          'h2.film-name.dynamic-name',
+        )
+        if (title) {
+          const thumbnail = document.querySelector<HTMLImageElement>(
+            '#ani_detail > div > div > div.anis-content > div.anisc-poster > div > img',
+          )?.src
 
-					presenceData.largeImageKey = thumbnail;
-					presenceData.details = "Checking Synopsis";
-					presenceData.state = title.textContent;
-					if (buttons) {
-						presenceData.buttons = [
-							{
-								label: "Check Synopsis",
-								url: href,
-							},
-						];
-					}
-				}
-			}
-		}
-	}
+          presenceData.largeImageKey = thumbnail
+          presenceData.details = 'Checking Synopsis'
+          presenceData.state = title.textContent
+          if (buttons) {
+            presenceData.buttons = [
+              {
+                label: 'Check Synopsis',
+                url: href,
+              },
+            ]
+          }
+        }
+      }
+    }
+  }
 
   presence.setActivity(presenceData)
 })


### PR DESCRIPTION
## Description 
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
This is a presence for the AnimeKai website. It will display which page the user is currently viewing and the name of the anime the user is
## Acknowledgements
- [x] I read the [Presence Guidelines](https://github.com/PreMiD/Presences/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Presences/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!-- 
    Screenshots of the presence settings (if applicable) and at least TWO screenshots of the presence displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->

![image](https://github.com/user-attachments/assets/c994facc-3426-4382-a67f-4d4ae14944e3)
![image](https://github.com/user-attachments/assets/cf435ff0-0f8f-4b42-8f77-38e526eef70e)


</details>
